### PR TITLE
Flush / Stats / Key Listings: backfilled missing methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Methods
 <tr><td>decrement( $key, $value = 1 )</td><td>Decrements $key by $value</td></tr>
 <tr><td>delete( $key )</td><td>Removes a single key from server</td></tr>
 <tr><td>deleteMulti( array $keys )</td><td>Removes group of keys from server(s)</td></tr>
+<tr><td>flush()</td><td>Removes all keys from server(s)</td></tr>
+<tr><td>getAllKeys()</td><td>Retrieves the full keylist from server(s)</td></tr>
+<tr><td>getStats()</td><td>Retrieves usage stats from server(s)</td></tr>
+<tr><td>bind( $event_name, callable $handler )</td><td>Provide handlers for cache-specific events</td></tr>
 <tr><td>close()</td><td>Disconnects from active connections</td></tr>
 </table>
 

--- a/src/Adapters/AdapterAbstract.php
+++ b/src/Adapters/AdapterAbstract.php
@@ -170,6 +170,48 @@ abstract class AdapterAbstract implements CacheAdapterInterface {
 
 
   /**
+   * {@inheritDoc}
+   */
+  public function flush() {
+
+    $action = ( function() {
+      return $this->_flush();
+    } );
+
+    return $this->_execute( $action, __FUNCTION__, null, true );
+
+  } // flush
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getAllKeys() {
+
+    $action = ( function() {
+      return $this->_getAllKeys();
+    } );
+
+    return $this->_execute( $action, __FUNCTION__, '' );
+
+  } // getAllKeys
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getStats() {
+
+    $action = ( function() {
+      return $this->_getStats();
+    } );
+
+    return $this->_execute( $action, __FUNCTION__, '' );
+
+  } // getStats
+
+
+  /**
    * @param string   $event_name
    * @param callable $handler
    */

--- a/src/Adapters/MemcachedAdapter.php
+++ b/src/Adapters/MemcachedAdapter.php
@@ -185,6 +185,42 @@ class MemcachedAdapter extends AdapterAbstract {
 
 
   /**
+   * {@inheritDoc}
+   *
+   * @see http://php.net/manual/en/memcache.flush.php
+   */
+  protected function _flush() {
+
+    return $this->_connection->flush();
+
+  } // _flush
+
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see http://php.net/manual/en/memcached.getallkeys.php
+   */
+  protected function _getAllKeys() {
+
+    return $this->_connection->getAllKeys();
+
+  } // _getAllKeys
+
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see http://php.net/manual/en/memcache.getstats.php
+   */
+  protected function _getStats() {
+
+    return $this->_connection->getStats();
+
+  } // _getStats
+
+
+  /**
    * Closes connection to server(s)
    */
   protected function _close() {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -3,6 +3,7 @@
 namespace Behance\NBD\Cache;
 
 use Behance\NBD\Cache\Services\ConfigService;
+use Behance\NBD\Cache\Exceptions\SystemRequirementException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class Factory {
@@ -13,19 +14,20 @@ class Factory {
   const TYPE_MEMCACHE      = 'Memcache';
   const TYPE_MEMCACHED     = 'Memcached';
 
+
   /**
    * TODO: auto-choose type based on available extensions
    *
    * @param Behance\NBD\Cache\Services\ConfigService $config
-   * @param string $type
+   * @param string $type  which kind of adapter to build, if omitted will choose automatically
    * @param Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
    *
    * @return Behance\NBD\Cache\Interfaces\AdapterInterface
    */
-  public static function create( ConfigService $config, $type, EventDispatcherInterface $event_dispatcher = null ) {
+  public static function create( ConfigService $config, $type = null, EventDispatcherInterface $event_dispatcher = null ) {
 
     $servers = $config->getServers();
-    $class   = self::NAMESPACE_ADAPTERS . $type . self::ADAPTER_SUFFIX;
+    $class   = self::NAMESPACE_ADAPTERS . static::_chooseAdapterType( $type ) . self::ADAPTER_SUFFIX;
     $adapter = new $class( $event_dispatcher );
 
     $adapter->addServers( $servers );
@@ -33,5 +35,33 @@ class Factory {
     return $adapter;
 
   } // create
+
+
+  /**
+   * @throws Behance\NBD\Cache\Exceptions\SystemRequirementException  when no cache backends are available
+   *
+   * @param string|null $type
+   *
+   * @return string
+   */
+  protected static function _chooseAdapterType( $type ) {
+
+    // Adapter already provided? Use it
+    if ( !empty( $type ) ) {
+      return $type;
+    }
+
+    // Highest priority, memcached adapter
+    if ( extension_loaded( 'memcached' ) ) {
+      return self::TYPE_MEMCACHED;
+    }
+
+    if ( extension_loaded( 'memcache' ) ) {
+      return self::TYPE_MEMCACHE;
+    }
+
+    throw new SystemRequirementException( "No cache extensions installed or available" );
+
+  } // _chooseAdapterType
 
 } // Factory

--- a/src/Interfaces/CacheAdapterInterface.php
+++ b/src/Interfaces/CacheAdapterInterface.php
@@ -104,6 +104,28 @@ interface CacheAdapterInterface {
 
 
   /**
+   * Invalidates the entire contents of a cache pool
+   *
+   * @return bool
+   */
+  public function flush();
+
+
+  /**
+   * Retrieves the first 1MB of keys, only should be used during development
+   *
+   * @return array
+   */
+  public function getAllKeys();
+
+
+  /**
+   * @return array
+   */
+  public function getStats();
+
+
+  /**
    * Disconnects from server(s)
    */
   public function close();

--- a/tests/unit/Adapters/MemcacheAdapterTest.php
+++ b/tests/unit/Adapters/MemcacheAdapterTest.php
@@ -62,7 +62,9 @@ class MemcacheAdapterTest extends BaseTest {
         'increment' => [ 'increment', [ $key, $value, 1 ], true ],
         'decrement' => [ 'decrement', [ $key, $value, 1 ], true ],
         'delete'    => [ 'delete',    [ $key ],            true ],
+        'flush'     => [ 'flush',     [],                  true ],
         'close'     => [ 'close',     [],                  true ],
+        'getStats'  => [ 'getStats',  [],                  true ],
     ];
 
   } // passthruProvider
@@ -173,5 +175,133 @@ class MemcacheAdapterTest extends BaseTest {
     $mock->addServers( $this->_server_config );
 
   } // addServers
+
+
+  /**
+   * @test
+   * @dataProvider extendedStatsProvider
+   */
+  public function getAllKeys( $results, $slabs, $cachedumps = [] ) {
+
+    $callback = ( function( $key, $slab_id = null ) use ( $slabs, $cachedumps ) {
+
+      if ( $key === MemcacheAdapter::STAT_KEY_SLABS ) {
+        return $slabs;
+      }
+
+      if ( $key === MemcacheAdapter::STAT_KEY_DUMP ) {
+        return $cachedumps[ $slab_id ];
+      }
+
+    } );
+
+
+    $memcache = $this->getMock( $this->_cache, [ 'getExtendedStats' ] );
+
+    $memcache->expects( $this->atLeastOnce() )
+      ->method( 'getExtendedStats' )
+      ->will( $this->returnCallback( $callback ) );
+
+    $adapter = new MemcacheAdapter( null, $memcache );
+
+    $this->assertEquals( $results, $adapter->getAllKeys() );
+
+  } // getAllKeys
+
+
+  /**
+   * @return array
+   */
+  public function extendedStatsProvider() {
+
+    $server1  = 'cache1.com:11211';
+    $server2  = 'cache2.com:11212';
+
+    $slab_id1 = 1234;
+    $slab_id2 = 5678;
+    $slab_id3 = 9012;
+    $slab_id4 = 3456;
+
+    $key1  = 'key1';
+    $key2  = 'key2';
+    $key3  = 'key3';
+    $key4  = 'key4';
+    $key5  = 'key5';
+    $key6  = 'key6';
+    $key7  = 'key7';
+    $key8  = 'key8';
+    $key9  = 'key9';
+    $key10 = 'key10';
+    $key11 = 'key11';
+    $key12 = 'key12';
+    $key13 = 'key13';
+    $key14 = 'key14';
+    $key15 = 'key15';
+    $key16 = 'key16';
+
+    $slabs = [
+        $server1 => [
+            $slab_id1 => [ 'chunk_size' => 96,   'chunks_per_page' => 10922, 'total_pages' => 1 ],
+            $slab_id2 => [ 'chunk_size' => 200,  'chunks_per_page' => 40923, 'total_pages' => 3 ]
+        ],
+        $server2 => [
+            $slab_id3 => [ 'chunk_size' => 2196, 'chunks_per_page' => 51922, 'total_pages' => 6 ],
+            $slab_id4 => [ 'chunk_size' => 4191, 'chunks_per_page' => 122,   'total_pages' => 12 ]
+        ]
+    ];
+
+    $cachedump1 = [
+        $server1 => [ $key1 => [ 1, 2 ], $key2 => [ 3, 4 ] ],
+        $server2 => [ $key3 => [ 5, 6 ], $key4 => [ 7, 8 ] ]
+    ];
+
+    $cachedump2 = [
+        $server1 => [ $key5 => [ 9,  10 ], $key6 => [ 11, 12 ] ],
+        $server2 => [ $key7 => [ 14, 15 ], $key8 => [ 15, 16 ] ]
+    ];
+
+    $cachedump3 = [
+        $server1 => [ $key9  => [ 1, 2 ], $key10 => [ 3, 4 ] ],
+        $server2 => [ $key11 => [ 5, 6 ], $key12 => [ 7, 8 ] ]
+    ];
+
+    $cachedump4 = [
+        $server1 => [ $key13 => [ 1, 2 ], $key14 => [ 3, 4 ] ],
+        $server2 => [ $key15 => [ 5, 6 ], $key16 => [ 7, 8 ] ]
+    ];
+
+    $cachedumps  = [
+        $slab_id1 => $cachedump1,
+        $slab_id2 => $cachedump2,
+        $slab_id3 => $cachedump3,
+        $slab_id4 => $cachedump4
+    ];
+
+    $key_results = [ $key1, $key2, $key3, $key4, $key5, $key6, $key7, $key8, $key9, $key10, $key11, $key12, $key13, $key14, $key15, $key16 ];
+
+
+
+    $partial_slabs = [
+        $server1 => [
+            $slab_id1 => [ 'chunk_size' => 96,   'chunks_per_page' => 10922, 'total_pages' => 1 ],
+        ]
+    ];
+
+    $partial_cachedump1 = [
+        $server1 => [ $key1 => [ 1, 2 ], $key2 => 'not-an-array', $key3 => [ 5, 6 ], $key4 => [ 7, 8 ] ],
+    ];
+
+    $partial_results    = [ $key1, $key3, $key4 ];
+    $partial_cachedumps = [
+        $slab_id1 => $partial_cachedump1
+    ];
+
+    return [
+        'Empty Slabs'  => [ [], [] ],
+        'Full Slabs'   => [ $key_results, $slabs, $cachedumps ],
+        'Partial Slab' => [ $partial_results, $partial_slabs, $partial_cachedumps ]
+    ];
+
+  } // extendedStatsProvider
 
 } // MemcacheAdapterTest

--- a/tests/unit/Adapters/MemcachedAdapterTest.php
+++ b/tests/unit/Adapters/MemcachedAdapterTest.php
@@ -65,6 +65,9 @@ class MemcachedAdapterTest extends BaseTest {
         'decrement'   => [ 'decrement',   [ $key, $value, 1 ],     true ],
         'delete'      => [ 'delete',      [ $key ],                true ],
         'deleteMulti' => [ 'deleteMulti', [ $keys ],               true ],
+        'flush'       => [ 'flush',       [],                      true ],
+        'getStats'    => [ 'getStats',    [],                      $keys ],
+        'getAllKeys'  => [ 'getAllKeys',  [],                      $keys ],
     ];
 
   } // passthruProvider


### PR DESCRIPTION
Added `getAllKeys` and `getStats` and `flush`